### PR TITLE
Exporting "SubsCache" in package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -20,4 +20,6 @@ Package.onUse(function(api) {
     'src/subsCache.coffee',
   ], ['client', 'server']);
 
+
+  api.export("SubsCache", ['client', 'server']);
 });


### PR DESCRIPTION
This allows to use the package as Meteor >=1.3 module.