### PR TITLE
Remove object scope of the main class

### DIFF
--- a/src/subsCache.coffee
+++ b/src/subsCache.coffee
@@ -29,7 +29,7 @@ callbacksFromArgs = (args)->
   else
     {}
 
-class @SubsCache
+class SubsCache
   @caches: []
   
   constructor: (obj) ->


### PR DESCRIPTION
This way the class is exported as intended.

I think this is necessary for Meteor 1.4, I get `SubsCache is undefined` otherwise.

Thanks for having a look.
