### PR TITLE
Use vanilla Timeout() functions instead of the Meteor versions

### DIFF
--- a/src/subsCache.coffee
+++ b/src/subsCache.coffee
@@ -137,10 +137,10 @@ class @SubsCache
           stop: -> @delayedStop()
           delayedStop: ->
             if expireTime >= 0
-              @timerId = Meteor.setTimeout(@stopNow.bind(this), expireTime*1000*60)
+              @timerId = setTimeout(@stopNow.bind(this), expireTime*1000*60)
           restart: ->
             # if we'are restarting, then stop the timer
-            Meteor.clearTimeout(@timerId)
+            clearTimeout(@timerId)
             @start()
           stopNow: ->
             @compsCount -= 1


### PR DESCRIPTION
Using Meteor.setTimeout() causes errors when the computation is invalidated from inside a simulation:
  Error: Can't set timers inside simulations

On the client setTimeout() can be used directly to avoid this.

I saw you deprecated the module but hope it's still possible to merge this. Thanks!
