### PR TITLE
Implemented Mocha Tests for most of the relevant functionality +  bugs fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Initialize with optional `expireAfter` (default 5) and `cacheLimit` (default 10)
     // second argument is cacheLimit -- default is 10
 ```
 
-- `subsCache.allReady()` tells you if all subscriptions in the cache are ready
+- `subsCache.ready()` tells you if all subscriptions in the cache are ready
 
 - `sub = subsCache.subscribe(...)` creates a subscription just like `Meteor.subscribe`
 

--- a/package.js
+++ b/package.js
@@ -20,6 +20,18 @@ Package.onUse(function(api) {
     'src/subsCache.js',
   ], ['client','server']);
 
-
   api.export("SubsCache", ['client','server']);
+});
+
+Package.onTest(function(api) {
+  api.use([
+    'underscore',
+    'ecmascript',
+    'ejson',
+    'tracker',
+    'reactive-var',
+    'ccorcos:subs-cache',
+    'practicalmeteor:chai'
+	], ['client', 'server']);
+  api.mainModule('src/subsCache.tests.js');
 });

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'ccorcos:subs-cache',
   summary: 'A package for caching Meteor subscriptions.',
-  version: '0.9.0',
+  version: '0.9.1',
   git: 'https://github.com/ccorcos/meteor-subs-cache'
 });
 
@@ -10,6 +10,7 @@ Package.onUse(function(api) {
 
   api.use([
     'underscore',
+    'ecmascript',
     'ejson',
     'tracker',
     'reactive-var'

--- a/src/subsCache.js
+++ b/src/subsCache.js
@@ -31,7 +31,7 @@ function callbacksFromArgs(args){
   }
 };
 
-SubsCache = function(expireAfter, cacheLimit) {
+SubsCache = function(expireAfter, cacheLimit, debug=false) {
   var self = this;
 
   this.debug = false;

--- a/src/subsCache.js
+++ b/src/subsCache.js
@@ -37,7 +37,7 @@ function callbacksFromArgs(args){
 SubsCache = function(expireAfter, cacheLimit, debug=false) {
   var self = this;
 
-  this.debug = false;
+  this.debug = debug;
   this.expireAfter = expireAfter || 5;
   this.cacheLimit = cacheLimit || 10;
   this.cache = {};

--- a/src/subsCache.js
+++ b/src/subsCache.js
@@ -157,7 +157,10 @@ SubsCache = function(expireAfter, cacheLimit, debug=false) {
         },
         restart: function() {
           // if we'are restarting, then stop the current timer (previous ones still tick otherwise we would have inconsistencies)
-          if (this.timerId) clearTimeout(this.timerId);
+          if (this.timerId) {
+            clearTimeout(this.timerId);
+            this.timerId = null;
+          }
           return this.start();
         },
         stopNow: function() {

--- a/src/subsCache.js
+++ b/src/subsCache.js
@@ -8,7 +8,6 @@ function hasCallbacks(args){
     var lastArg = args[args.length-1];
     var isFct = _.isFunction(lastArg);
     var retValue = !!(lastArg && _.any([lastArg.onReady, lastArg.onError, lastArg.onStop], _.isFunction));
-    console.log(isFct, retValue);
     return  isFct || retValue;
   }else{
     return false;

--- a/src/subsCache.js
+++ b/src/subsCache.js
@@ -2,7 +2,7 @@ import { EJSON } from 'meteor/ejson'
 import {ReactiveVar} from 'meteor/reactive-var';
 
 
-function hasCallbacks(args){
+export const hasCallbacks = function(args){
   // this logic is copied from Meteor.subscribe found in
   // https://github.com/meteor/meteor/blob/master/packages/ddp/livedata_connection.js
   if (args.length) {
@@ -11,7 +11,7 @@ function hasCallbacks(args){
   }
 };
 
-function withoutCallbacks(args){
+export const withoutCallbacks = function(args){
   if (hasCallbacks(args)) {
     return args.slice(0,args.length-1);
   } else {
@@ -19,7 +19,7 @@ function withoutCallbacks(args){
   }
 };
 
-function callbacksFromArgs(args){
+export const callbacksFromArgs = function(args){
   if (hasCallbacks(args)) {
     if (_.isFunction(args[args.length-1])) {
       return {onReady: args[args.length-1]};
@@ -41,6 +41,15 @@ SubsCache = function(expireAfter, cacheLimit, debug=false) {
   this.allReady = new ReactiveVar(true);
 
   SubsCache.caches.push(this);
+
+  // required in order to make
+  // to make helpers accessible
+  // to unit tests
+  this.helpers = {
+	  hasCallbacks: hasCallbacks,
+	  withoutCallbacks: withoutCallbacks,
+	  callbacksFromArgs: callbacksFromArgs
+  }
 
   this.ready = function() {
     return this.allReady.get();

--- a/src/subsCache.js
+++ b/src/subsCache.js
@@ -42,15 +42,6 @@ SubsCache = function(expireAfter, cacheLimit, debug=false) {
 
   SubsCache.caches.push(this);
 
-  // required in order to make
-  // to make helpers accessible
-  // to unit tests
-  this.helpers = {
-	  hasCallbacks: hasCallbacks,
-	  withoutCallbacks: withoutCallbacks,
-	  callbacksFromArgs: callbacksFromArgs
-  }
-
   this.ready = function() {
     return this.allReady.get();
   }
@@ -232,7 +223,17 @@ SubsCache = function(expireAfter, cacheLimit, debug=false) {
 SubsCache.caches = [];
 SubsCache.clearAll = function() {
   this.caches.map(function(s) { s.clear()});
-}
+};
+
 SubsCache.computeHash = function(...args) {
   return EJSON.stringify(withoutCallbacks(args));
+};
+
+// required in order to make
+// to make helpers accessible
+// to unit tests
+SubsCache.helpers = {
+	hasCallbacks: hasCallbacks,
+	withoutCallbacks: withoutCallbacks,
+	callbacksFromArgs: callbacksFromArgs
 }

--- a/src/subsCache.js
+++ b/src/subsCache.js
@@ -1,25 +1,29 @@
 import { EJSON } from 'meteor/ejson'
 import {ReactiveVar} from 'meteor/reactive-var';
 
-
-export const hasCallbacks = function(args){
+function hasCallbacks(args){
   // this logic is copied from Meteor.subscribe found in
   // https://github.com/meteor/meteor/blob/master/packages/ddp/livedata_connection.js
-  if (args.length) {
-    let lastArg = args[args.length-1];
-    return _.isFunction(lastArg) || (lastArg && _.any([lastArg.onReady, lastArg.onError, lastArg.onStop], _.isFunction));
+  if (args && args.length) {
+    var lastArg = args[args.length-1];
+    var isFct = _.isFunction(lastArg);
+    var retValue = !!(lastArg && _.any([lastArg.onReady, lastArg.onError, lastArg.onStop], _.isFunction));
+    console.log(isFct, retValue);
+    return  isFct || retValue;
+  }else{
+    return false;
   }
 };
 
-export const withoutCallbacks = function(args){
+function withoutCallbacks(args){
   if (hasCallbacks(args)) {
     return args.slice(0,args.length-1);
   } else {
-    return args.slice();
+    return args && args.length > 0 ? args.slice() : [];
   }
 };
 
-export const callbacksFromArgs = function(args){
+function callbacksFromArgs(args){
   if (hasCallbacks(args)) {
     if (_.isFunction(args[args.length-1])) {
       return {onReady: args[args.length-1]};

--- a/src/subsCache.tests.js
+++ b/src/subsCache.tests.js
@@ -1,0 +1,91 @@
+/* eslint-env mocha */
+import {Meteor} from 'meteor/meteor';
+import {chai, assert} from 'meteor/practicalmeteor:chai';
+
+describe("SubsCache - Common", function () {
+
+	it("is globally accessible", function () {
+		assert.isDefined(SubsCache);
+		assert.isNotNull(SubsCache);
+	});
+
+});
+
+describe("SubsCache - instantiation", function () {
+
+	it("is instatiated with default settings", function () {
+		assert.fail("not yet implemented");
+	});
+
+	it("is instantiated with custom settings", function () {
+		assert.fail("not yet implemented");
+	});
+});
+
+describe("SubsCache - subscribe", function () {
+
+	it("creates a subscription just like Meteor.subscribe", function () {
+		assert.fail("not yet implemented");
+		//sub = subsCache.subscribe(...)
+	});
+
+	it("allow you to set the expiration other than the defualt", function () {
+		assert.fail("not yet implemented");
+		//subsCache.subscribeFor(expireIn, ...)
+	});
+
+	it("allow you to set the expiration other than the defualt", function () {
+		assert.fail("not yet implemented");
+		//subsCache.subscribeFor(expireIn, ...)
+	});
+});
+
+describe("SubsCache - ready", function () {
+
+	describe("individual", function () {
+
+		it("tells you if an individual subscription is ready", function () {
+			assert.fail("not yet implemented");
+			//sub.ready()
+		});
+
+		it("will call a function once an individual subscription is ready", function () {
+			assert.fail("not yet implemented");
+			//sub.onReady(func)
+		});
+	})
+
+	describe("all", function () {
+
+		it("tells you if all subscriptions in the cache are ready", function () {
+			assert.fail("not yet implemented");
+			//subsCache.allReady()
+		});
+
+		it("will call a function once all subscription are ready", function () {
+			assert.fail("not yet implemented");
+			//subsCache.onReady(func)
+		});
+
+	})
+
+});
+
+
+describe("SubsCache - stop", function () {
+
+	it("will cache a subscription and stop after expireAfter unless restarted with sub.restart()", function () {
+		assert.fail("not yet implemented");
+		//sub.stop()
+	});
+
+	it("will stop a subscription immediately and remove it from the cache.", function () {
+		assert.fail("not yet implemented");
+		//sub.stopNow()
+	});
+
+	it("will stop all subscription immediately", function () {
+		assert.fail("not yet implemented");
+		//subsCache.clear()
+	});
+});

--- a/src/subsCache.tests.js
+++ b/src/subsCache.tests.js
@@ -37,6 +37,12 @@ var exists = function (value) {
 	assert.isNotNull(value);
 };
 
+var notExists = function(value) {
+	var isUndefined = typeof value === "undefined";
+	var isNull = value === null;
+	assert.isTrue(isUndefined || isNull);
+}
+
 //==========================//
 // TESTS                    //
 //==========================//
@@ -213,9 +219,18 @@ describe("SubsCache - subscribe", function () {
 		var hashSome = SubsCache.computeHash(publicationSomeDOcuments);
 
 		exists(subsCache.cache[hashSome]);
-		assert.isUndefined(subsCache.cache[hashAll]);
+		notExists(subsCache.cache[hashAll]);
 	});
 
+	it ("resets the time when restarted", function () {
+		var subsCache = new SubsCache();
+		var subAll = subsCache.subscribeFor(10,publicationAllDocuments);
+		notExists(subAll.timerId);
+		subAll.stop();
+		exists(subAll.timerId);
+		subAll.restart();
+		notExists(subAll.timerId);
+	})
 });
 
 import { Tracker } from 'meteor/tracker'

--- a/src/subsCache.tests.js
+++ b/src/subsCache.tests.js
@@ -2,14 +2,63 @@
 import {Meteor} from 'meteor/meteor';
 import {chai, assert} from 'meteor/practicalmeteor:chai';
 
-describe("SubsCache - Common", function () {
+var exists = function (value) {
+	assert.isDefined(value);
+	assert.isNotNull(value);
+};
+
+describe("SubsCache", function () {
 
 	it("is globally accessible", function () {
-		assert.isDefined(SubsCache);
-		assert.isNotNull(SubsCache);
+		exists(SubsCache);
 	});
 
+	it("has global 'helpers' accessible", function () {
+		exists(SubsCache.helpers);
+	});
+
+	it("has global 'caches' accessible", function () {
+		exists(SubsCache.caches);
+	});
+
+	it("has global 'clearAll' accessible", function () {
+		exists(SubsCache.clearAll);
+	});
+
+	it("has global 'computeHash' accessible", function () {
+		exists(SubsCache.computeHash);
+	});
 });
+
+describe("SubsCache.helpers", function () {
+
+	var cb = function (err, res) {};
+
+	describe("hasCallbacks", function () {
+
+		it("returns true, if last argument is a callback", function () {
+			var hasCallbacks = SubsCache.helpers.hasCallbacks;
+			assert.isTrue(hasCallbacks.call(null, [cb]));
+			assert.isTrue(hasCallbacks.call(null, [null, cb]));
+			assert.isTrue(hasCallbacks.call(null, [null, null, cb]));
+		});
+
+		it("returns false, if last argument is not a callback", function () {
+			var hasCallbacks = SubsCache.helpers.hasCallbacks;
+			assert.isFalse(hasCallbacks.call(null, [1]));
+			assert.isFalse(hasCallbacks.call(null, ["foo"]));
+			assert.isFalse(hasCallbacks.call(null, [{}]));
+			assert.isFalse(hasCallbacks.call(null, [undefined]));
+			assert.isFalse(hasCallbacks.call(null, [null]));
+		});
+
+		it("returns false if no arguments are given", function () {
+			var hasCallbacks = SubsCache.helpers.hasCallbacks;
+			assert.isFalse(hasCallbacks.call(null, []));
+			assert.isFalse(hasCallbacks.call(null));
+		});
+	});
+})
 
 describe("SubsCache - instantiation", function () {
 

--- a/src/subsCache.tests.js
+++ b/src/subsCache.tests.js
@@ -58,6 +58,49 @@ describe("SubsCache.helpers", function () {
 			assert.isFalse(hasCallbacks.call(null));
 		});
 	});
+
+	describe("withoutCallbacks", function () {
+
+		it ("returns an array without callbacks on an array with callbacks", function () {
+			var withoutCallbacks = SubsCache.helpers.withoutCallbacks;
+
+			var withoutCb1 = withoutCallbacks.call(null, [cb]);
+			assert.deepEqual(withoutCb1, []);
+
+			var withoutCb2 = withoutCallbacks.call(null, [1,2,3, cb]);
+			assert.deepEqual(withoutCb2, [1,2,3]);
+		});
+
+		it ("returns an empty array on empty or non existent input", function () {
+			var withoutCallbacks = SubsCache.helpers.withoutCallbacks;
+
+			assert.deepEqual(withoutCallbacks.call(null), []);
+			assert.deepEqual(withoutCallbacks.call(null, null), []);
+			assert.deepEqual(withoutCallbacks.call(null, undefined), []);
+		});
+	});
+
+
+	describe("callbacksFromArgs", function () {
+
+		it ("extracts callbacks from args if existent", function () {
+			var callbacksFromArgs = SubsCache.helpers.callbacksFromArgs;
+
+			assert.deepEqual(callbacksFromArgs.call(null, [null, cb]), {onReady: cb});
+		});
+
+		it ("returns an empty object of no callback is existent in args", function () {
+			var callbacksFromArgs = SubsCache.helpers.callbacksFromArgs;
+
+			assert.deepEqual(callbacksFromArgs.call(null), {});
+			assert.deepEqual(callbacksFromArgs.call(null, []), {});
+			assert.deepEqual(callbacksFromArgs.call(null, [1]), {});
+			assert.deepEqual(callbacksFromArgs.call(null, ["foo"]), {});
+			assert.deepEqual(callbacksFromArgs.call(null, [null]), {});
+			assert.deepEqual(callbacksFromArgs.call(null, null), {});
+			assert.deepEqual(callbacksFromArgs.call(null, undefined), {});
+		});
+	});
 })
 
 describe("SubsCache - instantiation", function () {


### PR DESCRIPTION
**Test Suite**

There is now a subCache.tests.js file, that runs several test. Call it from the package directory via:

`meteor test-packages ./ --driver-package practicalmeteor:mocha`

The following tests are implemented and are passing:

**SubsCache**
-is globally accessible
-has global 'helpers' accessible
-has global 'caches' accessible
-has global 'clearAll' accessible
-has global 'computeHash' accessible

**SubsCache.helpers**
**hasCallbacks**
-returns true, if last argument is a callback ‣
-returns false, if last argument is not a callback ‣
-returns false if no arguments are given ‣
**withoutCallbacks**
-returns an array without callbacks on an array with callbacks
-returns an empty array on empty or non existent input
**callbacksFromArgs**
-extracts callbacks from args if existent
-returns an empty object of no callback is existent in args

**SubsCache - instantiation**
-is instantiated as SubsCache instance
-is instatiated with default settings
-is instantiated with custom settings

**SubsCache - subscribe**
-creates a subscription just like Meteor.subscribe
-has sub stored in instance's cache object
-allow you to set the expiration other than the defualt
-expires after given time1010ms
-delete the oldest subscription if the cache has overflown
-resets the time when restarted

**SubsCache - ready**
**individual**
-tells you if an individual subscription is ready111ms
-will call a function once an individual subscription is ready
**all**
-tells you if all subscriptions in the cache are ready
-will call a function once all subscription are ready

**SubsCache - stop**
-will cache a subscription and stop after expireAfter unless restarted with sub.restart()44ms
-will stop a subscription immediately and remove it from the cache.
-will stop all subscription immediately

**Improvements**

-Fixed hasCallbacks to make it consistently either return true or false. Before it returned either true, false or sometimes undefined or null.
-Make console.log statements only be executed when debug is passed to the construcut
-Imported missing ReactiveVar package


**Note:**

I made the changes backward compatible, so that there should be no change of other behavior / functionality.