### PR TITLE
Re-run subscription on args changed to support changing subscription parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Initialize with optional `expireAfter` (default 5) and `cacheLimit` (default 10)
     // second argument is cacheLimit -- default is 10
 ```
 
-- `subsCache.ready()` tells you if all subscriptions in the cache are ready
-
 - `sub = subsCache.subscribe(...)` creates a subscription just like `Meteor.subscribe`
 
 - `sub = subsCache.subscribeFor(expireIn, ...)` allow you to set the expiration other than the defualt.
 
 - `subsCache.clear()` will stop all subscription immediately
+
+- `subsCache.ready()` tells you if all subscriptions in the cache are ready
 
 - `subsCache.onReady(func)` will call a function once all subscription are ready
 
@@ -55,3 +55,9 @@ Initialize with optional `expireAfter` (default 5) and `cacheLimit` (default 10)
 - `sub.ready()` tells you if an individual subscription is ready
 
 - `sub.onReady(func)` will call a function once an individual subscription is ready
+
+## Testing
+
+You can run the mocha-based tests in watch mode via:
+
+`meteor test-packages ./ --driver-package practicalmeteor:mocha`

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'ccorcos:subs-cache',
   summary: 'A package for caching Meteor subscriptions.',
-  version: '0.9.1',
+  version: '0.9.2',
   git: 'https://github.com/ccorcos/meteor-subs-cache'
 });
 

--- a/src/SubsCache.tests.js
+++ b/src/SubsCache.tests.js
@@ -148,6 +148,35 @@ describe("SubsCache.helpers", function () {
 			assert.deepEqual(callbacksFromArgs.call(null, undefined), {});
 		});
 	});
+
+	describe("argsChanged", function () {
+
+		it ("compares loosely", function () {
+			var argsChanged = SubsCache.helpers.argsChanged;
+
+			assert.isTrue(argsChanged([], [1]));
+			assert.isTrue(argsChanged([1], []));
+			assert.isTrue(argsChanged([1], [2]));
+			assert.isTrue(argsChanged([1], [1,2]));
+			assert.isTrue(argsChanged([1,3], [1,2]));
+			assert.isTrue(argsChanged(["1"], [1]));
+			assert.isTrue(argsChanged(["1"], ["1", "2"]));
+
+			assert.isFalse(argsChanged([],[]));
+			assert.isFalse(argsChanged([1],[1]));
+			assert.isFalse(argsChanged(["1"],["1"]));
+		});
+
+		it ("compares deep", function () {
+			var argsChanged = SubsCache.helpers.argsChanged;
+
+			assert.isTrue(argsChanged([{}], [{val:1}]));
+			assert.isTrue(argsChanged([{val:2}], [{val:1}]));
+
+			assert.isFalse(argsChanged([{val:1}], [{val:1}]));
+			assert.isFalse(argsChanged([{}], [{}]));
+		});
+	});
 })
 
 describe("SubsCache - instantiation", function () {
@@ -197,6 +226,22 @@ describe("SubsCache - subscribe", function () {
 
 		var ref = subsCache.cache[hash];
 		assert.deepEqual(ref, sub);
+	});
+
+	it ("allows to change parameters", function () {
+		var subsCache = new SubsCache();
+		var sub = subsCache.subscribe(publicationAllDocuments, {_id:"01234567"}, 10, {sort: {_id:1}});
+		var hash = SubsCache.computeHash(publicationAllDocuments);
+		assert.equal(sub.hash, hash);
+
+		var ref = subsCache.cache[hash];
+		assert.deepEqual(ref, sub);
+
+		var sub2 = subsCache.subscribe(publicationAllDocuments, {_id:"01234567"}, 15, {sort: {_id:1}});
+		ref = subsCache.cache[hash];
+		assert.deepEqual(ref, sub2);
+		assert.notDeepEqual(sub, sub2);
+		assert.notDeepEqual(sub.args, sub2.args);
 	});
 
 	it("allow you to set the expiration other than the defualt", function () {


### PR DESCRIPTION
Basically added a check, whether the function is called with different arguments and if so, runs through as like a first call and basically updates the sub.

There are also some tests provided. Please not, that there is some untested code remaining (such as hooks). There is more test support requirement to gain a good test coverage.

**Please test well, before merging this PR.** 