### PR TITLE
add missing packages

### DIFF
--- a/package.js
+++ b/package.js
@@ -31,7 +31,9 @@ Package.onTest(function(api) {
     'tracker',
     'reactive-var',
     'ccorcos:subs-cache',
-    'practicalmeteor:chai'
+    'practicalmeteor:chai',
+    'coffeescript@1.12.7_3',
+    'practicalmeteor:mocha@2.4.5_6'
 	], ['client', 'server']);
   api.mainModule('src/SubsCache.tests.js');
 });


### PR DESCRIPTION
I could not manage to run tests with `meteor test-packages ./ --driver-package practicalmeteor:mocha`.
It looks like it is a problem with Meteor 1.6. See https://github.com/practicalmeteor/meteor-mocha/issues/94
It works after this changes.