### PR TITLE
fix(count): decrease count on restart

### DIFF
--- a/src/SubsCache.js
+++ b/src/SubsCache.js
@@ -178,10 +178,12 @@ SubsCache = function(expireAfter, cacheLimit, debug=false) {
           }
         },
         restart: function() {
+          if (self.debug) console.log('SubsCache - restart: ' + this.hash);
           // if we'are restarting, then stop the current timer (previous ones still tick otherwise we would have inconsistencies)
           if (this.timerId) {
             clearTimeout(this.timerId);
             this.timerId = null;
+            this.count -= 1;
           }
           return this.start();
         },


### PR DESCRIPTION
Issue:
Subscriptions are not stopped sometimes because SubsCache thinks that there are active computations.

Reason:
When `restart` is called, the timer is cleared and `start` is called which increases the count by 1.

Solution:
Decrease count.