### PR TITLE
fix(tests): use cultofcoders:mocha to support Meteor > 1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Initialize with optional `expireAfter` (default 5) and `cacheLimit` (default 10)
 
 You can run the mocha-based tests in watch mode via:
 
-`meteor test-packages ./ --driver-package practicalmeteor:mocha`
+`meteor test-packages ./ --driver-package cultofcoders:mocha`
 
 ## Known Issues
 

--- a/package.js
+++ b/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom('METEOR@1');
+  api.versionsFrom('METEOR@1.6.1');
 
   api.use([
     'ecmascript@0.8.3',
@@ -32,7 +32,7 @@ Package.onTest(function(api) {
     'reactive-var',
     'ccorcos:subs-cache',
     'practicalmeteor:chai',
-    'practicalmeteor:mocha@2.4.5_6'
+    'cultofcoders:mocha'
 	], ['client', 'server']);
   api.mainModule('src/SubsCache.tests.js');
 });

--- a/src/SubsCache.tests.js
+++ b/src/SubsCache.tests.js
@@ -2,6 +2,7 @@
 import {Meteor} from 'meteor/meteor';
 import {Mongo} from 'meteor/mongo';
 import {chai, assert} from 'meteor/practicalmeteor:chai';
+import {describe, it} from 'meteor/cultofcoders:mocha';
 
 //==========================//
 // CREATE SOME PUBLICATIONS //


### PR DESCRIPTION
**Issue:**
`meteor test-packages ./ --driver-package practicalmeteor:mocha` is failing for Meteor > 1.6.1 (see https://github.com/practicalmeteor/meteor-mocha/issues/100). 
Error:
```
I20180515-12:12:19.135(2)? Exception while invoking method 'mocha/runServerTests' Error: invalid reporter "[object Object]"
I20180515-12:12:19.136(2)?     at Mocha.reporter (C:\Users\lmachens\AppData\Local\.meteor\packages\practicalmeteor_mocha-core\1.0.1\npm\node_modules\mocha\lib\mocha.js:180:13)
I20180515-12:12:19.137(2)?     at MochaRunner.coffee.js.MochaRunner.runServerTests (packages/practicalmeteor_mocha/meteor/src/lib/MochaRunner.coffee:72:19)
I20180515-12:12:19.137(2)?     at MochaRunner.runServerTests (packages/practicalmeteor_mocha/meteor/src/lib/MochaRunner.coffee:1:1)
I20180515-12:12:19.139(2)?     at maybeAuditArgumentChecks (packages/ddp-server/livedata_server.js:1768:12)
I20180515-12:12:19.139(2)?     at DDP._CurrentMethodInvocation.withValue (packages/ddp-server/livedata_server.js:719:19)
I20180515-12:12:19.140(2)?     at Meteor.EnvironmentVariable.EVp.withValue (packages\meteor.js:1186:12)
I20180515-12:12:19.140(2)?     at DDPServer._CurrentWriteFence.withValue (packages/ddp-server/livedata_server.js:717:46)
I20180515-12:12:19.141(2)?     at Meteor.EnvironmentVariable.EVp.withValue (packages\meteor.js:1186:12)
I20180515-12:12:19.142(2)?     at Promise (packages/ddp-server/livedata_server.js:715:46)
I20180515-12:12:19.142(2)?     at new Promise (<anonymous>)
I20180515-12:12:19.143(2)?     at Session.method (packages/ddp-server/livedata_server.js:689:23)
I20180515-12:12:19.143(2)?     at packages/ddp-server/livedata_server.js:559:43
```

**Solution:**
`cultofcoders:mocha` works fine. 

**Other:**
Tests are failing (should be fixed in other PR):
![image](https://user-images.githubusercontent.com/10058950/40051143-00ca1b02-583a-11e8-9dc9-2960098bb7ef.png)
