### PR TITLE
return subscription handle from Meteor.subscribe and fix subscription args

### DIFF
--- a/src/SubsCache.js
+++ b/src/SubsCache.js
@@ -97,7 +97,7 @@ SubsCache = function(expireAfter, cacheLimit, debug = false) {
   this.subscribeFor = function(expireTime, ...args) {
     if (Meteor.isServer) {
       // If we're using fast-render for SSR
-      Meteor.subscribe.apply(Meteor.args);
+      return Meteor.subscribe.apply(args);
     } else {
       var hash = EJSON.stringify(withoutCallbacks(args));
       var self = this;


### PR DESCRIPTION
Currently the subscription handle isn't returned, and so on the server `subsCache.subscribe().ready()` throws an error.

Additionally there is no such property `Meteor.args` so console logs message: `There is no such publish handler named: undefined`


