### PR TITLE
Clear interval on clear

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "ccorcos:subs-cache",
   summary: "A package for caching Meteor subscriptions.",
-  version: "0.9.8",
+  version: "0.9.9",
   git: "https://github.com/ccorcos/meteor-subs-cache"
 });
 

--- a/src/SubsCache.js
+++ b/src/SubsCache.js
@@ -79,6 +79,10 @@ SubsCache = function(expireAfter, cacheLimit, debug = false) {
 
   this.clear = function() {
     return Object.values(this.cache).map(function(sub) {
+      if (sub.timerId) {
+        clearInterval(sub.timerId);
+        sub.timerId = null;
+      }
       sub.stopNow();
     });
   };

--- a/src/SubsCache.tests.js
+++ b/src/SubsCache.tests.js
@@ -392,4 +392,37 @@ describe("SubsCache - stop", function() {
       done();
     });
   });
+
+
+});
+
+
+describe("SubsCache - expiration", function() {
+
+  it ("sets starts ab interval for expiration, if stopped", function(done) {
+    var subsCache = new SubsCache(1000000);
+    var sub1 = subsCache.subscribe(publicationAllDocuments);
+
+    subsCache.onReady(function() {
+      assert.isNull(sub1.timerId);
+      sub1.stop();
+      assert.isNotNull(sub1.timerId);
+      done();
+    });
+  });
+
+  it("clears the interval on clear", function(done) {
+    var subsCache = new SubsCache(1000000);
+    var sub1 = subsCache.subscribe(publicationAllDocuments);
+
+    subsCache.onReady(function() {
+      assert.isNull(sub1.timerId);
+      sub1.stop();
+      assert.isNotNull(sub1.timerId);
+      subsCache.clear();
+      assert.isNull(sub1.timerId);
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
Fixing #60 

Clears the interval on `sub.clear()` and sets the `timerId` to null which is called for every sub when `clearAll()` is called.