### PR TITLE
Fix missing stop of subs when cache overflows / cache limit is reached

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "ccorcos:subs-cache",
   summary: "A package for caching Meteor subscriptions.",
-  version: "0.9.9",
+  version: "0.9.10",
   git: "https://github.com/ccorcos/meteor-subs-cache"
 });
 

--- a/src/SubsCache.js
+++ b/src/SubsCache.js
@@ -79,10 +79,7 @@ SubsCache = function(expireAfter, cacheLimit, debug = false) {
 
   this.clear = function() {
     return Object.values(this.cache).map(function(sub) {
-      if (sub.timerId) {
-        clearInterval(sub.timerId);
-        sub.timerId = null;
-      }
+      sub.clear();
       sub.stopNow();
     });
   };
@@ -223,6 +220,13 @@ SubsCache = function(expireAfter, cacheLimit, debug = false) {
                     this.hash
                 );
             }
+          },
+          clear() {
+            // clear timer if exists
+            if (this.timerId) {
+              clearInterval(this.timerId);
+              this.timerId = null;
+            }
           }
         };
 
@@ -247,7 +251,7 @@ SubsCache = function(expireAfter, cacheLimit, debug = false) {
           cachedSub.addHooks(callbacksFromArgs(args));
         }
 
-        // delete the oldest subscription with count = 0 if the cache has overflown
+        // delete the oldest subscription
         if (this.cacheLimit > 0) {
           var allSubs = Object.values(this.cache);
           var numSubs = allSubs.length;
@@ -263,10 +267,10 @@ SubsCache = function(expireAfter, cacheLimit, debug = false) {
                   " subscription(s)"
               );
             for (var i = 0; needToDelete && i < sortedSubs.length; i++) {
-              if (sortedSubs[i].count == 0) {
-                sortedSubs[i].stopNow();
-                needToDelete--;
-              }
+              var currentSub = sortedSubs[i];
+              currentSub.clear();
+              currentSub.stopNow();
+              needToDelete--;
             }
             if (self.debug && needToDelete)
               console.log(

--- a/src/SubsCache.tests.js
+++ b/src/SubsCache.tests.js
@@ -429,24 +429,42 @@ describe("SubsCache - expiration", function() {
 
 describe("Subscache - cache limit", function() {
 
-  it("stops and removes the oldest subscription with count = 0 if the cache has overflown", function(done) {
+  it("stops the oldest subscription if the cache has overflown", function(done) {
     var subsCache = new SubsCache(100, 1);
     var sub1 = subsCache.subscribe(publicationAllDocuments);
-    assert.equal(Object.keys(subsCache.cache).length, 1);
+    var sub2 = subsCache.subscribe(publicationSomeDOcuments);
+
     subsCache.onReady(function() {
-
-      var sub2 = subsCache.subscribe(publicationSomeDOcuments);
-      assert.equal(Object.keys(subsCache.cache).length, 1);
-
       assert.isFalse(sub1.ready());
-      assert.isNull(sub1.timerId);
-      
       assert.isTrue(sub2.ready());
       done();
     });
   });
 
+  it("removes the oldest subscription if the cache has overflown", function(done) {
+    var subsCache = new SubsCache(100, 1);
+    var sub1 = subsCache.subscribe(publicationAllDocuments);
+    var sub2 = subsCache.subscribe(publicationSomeDOcuments);
+
+    assert.equal(Object.keys(subsCache.cache).length, 1);
+    subsCache.onReady(function() {
+      assert.equal(Object.keys(subsCache.cache).length, 1);
+      done();
+    });
+  });
+
+
   it("clears the interval on the removed and stopped sub", function(done) {
-    assert.fail();
+    var subsCache = new SubsCache(100, 1);
+    var sub1 = subsCache.subscribe(publicationAllDocuments);
+
+    subsCache.onReady(function() {
+      assert.isNull(sub1.timerId);
+      sub1.stop();
+      assert.isNotNull(sub1.timerId);
+      var sub2 = subsCache.subscribe(publicationSomeDOcuments);
+      assert.isNull(sub1.timerId);
+      done();
+    });
   });
 });

--- a/src/SubsCache.tests.js
+++ b/src/SubsCache.tests.js
@@ -10,7 +10,8 @@ import { describe, it } from "meteor/cultofcoders:mocha";
 
 var FakeCollection = new Mongo.Collection("tests");
 var publicationAllDocuments = "FakeCollection.publication.all";
-var publicationSomeDOcuments = "FakeCollection.publication.some";
+var publicationOneDocuments = "FakeCollection.publication.some";
+var publicationSomeDOcuments = "FakeCollection.publication.one";
 var methodAddDocument = "FakeCollection.methods.add";
 
 if (Meteor.isServer) {
@@ -21,6 +22,7 @@ if (Meteor.isServer) {
   FakeCollection.insert({ value: 1 });
   FakeCollection.insert({ value: 1 });
   FakeCollection.insert({ value: 1 });
+
   Meteor.publish(publicationAllDocuments, function() {
     return FakeCollection.find();
   });
@@ -28,6 +30,11 @@ if (Meteor.isServer) {
   Meteor.publish(publicationSomeDOcuments, function() {
     return FakeCollection.find({ value: 1 });
   });
+
+  Meteor.publish(publicationOneDocuments, function() {
+    return FakeCollection.find({}, {limit: 1});
+  });
+
 
   var methods = {};
   methods[methodAddDocument] = function() {
@@ -433,10 +440,12 @@ describe("Subscache - cache limit", function() {
     var subsCache = new SubsCache(100, 1);
     var sub1 = subsCache.subscribe(publicationAllDocuments);
     var sub2 = subsCache.subscribe(publicationSomeDOcuments);
+    var sub3 = subsCache.subscribe(publicationOneDocuments);
 
     subsCache.onReady(function() {
       assert.isFalse(sub1.ready());
-      assert.isTrue(sub2.ready());
+      assert.isFalse(sub2.ready());
+      assert.isTrue(sub3.ready());
       done();
     });
   });
@@ -445,6 +454,7 @@ describe("Subscache - cache limit", function() {
     var subsCache = new SubsCache(100, 1);
     var sub1 = subsCache.subscribe(publicationAllDocuments);
     var sub2 = subsCache.subscribe(publicationSomeDOcuments);
+    var sub3 = subsCache.subscribe(publicationOneDocuments);
 
     assert.equal(Object.keys(subsCache.cache).length, 1);
     subsCache.onReady(function() {

--- a/src/SubsCache.tests.js
+++ b/src/SubsCache.tests.js
@@ -426,3 +426,27 @@ describe("SubsCache - expiration", function() {
   });
 
 });
+
+describe("Subscache - cache limit", function() {
+
+  it("stops and removes the oldest subscription with count = 0 if the cache has overflown", function(done) {
+    var subsCache = new SubsCache(100, 1);
+    var sub1 = subsCache.subscribe(publicationAllDocuments);
+    assert.equal(Object.keys(subsCache.cache).length, 1);
+    subsCache.onReady(function() {
+
+      var sub2 = subsCache.subscribe(publicationSomeDOcuments);
+      assert.equal(Object.keys(subsCache.cache).length, 1);
+
+      assert.isFalse(sub1.ready());
+      assert.isNull(sub1.timerId);
+      
+      assert.isTrue(sub2.ready());
+      done();
+    });
+  });
+
+  it("clears the interval on the removed and stopped sub", function(done) {
+    assert.fail();
+  });
+});


### PR DESCRIPTION
This fixes #59 

The new approach does not use `count` to determine the oldest sub but `startedAt` which uses timestamps.

Tests have been added, too.