### PR TITLE
Fix allReady not updated issue #20

### DIFF
--- a/src/SubsCache.js
+++ b/src/SubsCache.js
@@ -286,20 +286,22 @@ SubsCache = function(expireAfter, cacheLimit, debug = false) {
 
         // reactively set the allReady reactive variable
         if (this.allReadyComp != null) this.allReadyComp.stop();
-        Tracker.autorun(function(c) {
-          self.allReadyComp = c;
-          let subs = Object.values(self.cache);
-          if (subs.length > 0) {
-            return self.allReady.set(
-              subs
-                .map(function(x) {
-                  return x.ready();
-                })
-                .reduce(function(a, b) {
-                  return a && b;
-                })
-            );
-          }
+        Tracker.nonreactive(() => {
+          Tracker.autorun(function(c) {
+            self.allReadyComp = c;
+            let subs = Object.values(self.cache);
+            if (subs.length > 0) {
+              return self.allReady.set(
+                subs
+                  .map(function(x) {
+                    return x.ready();
+                  })
+                  .reduce(function(a, b) {
+                    return a && b;
+                  })
+              );
+            }
+          });
         });
       }
 


### PR DESCRIPTION
I have a context which can reproduce the allReady not work issue #20 with 85% chance.
So after quite some test, which indicated that Tracker.autorun is only called once.
Then, inspired by https://stackoverflow.com/questions/45201057/tracker-autorun-only-runs-once
It seems the Tracker.nonreactive wrapper somehow workaround this issue.
And after test, it does works.